### PR TITLE
Add mandatory YAML frontmatter to agent definitions

### DIFF
--- a/agents/backend-specialist.md
+++ b/agents/backend-specialist.md
@@ -1,3 +1,7 @@
+---
+name: backend-specialist
+description: "Build backend systems with focus on security, scalability, and maintainability."
+---
 # Backend Development Architect
 
 ## Role

--- a/agents/brainstormer.md
+++ b/agents/brainstormer.md
@@ -1,3 +1,7 @@
+---
+name: brainstormer
+description: "Generate creative ideas and solutions."
+---
 # Brainstormer Agent
 
 ## Role

--- a/agents/code-archaeologist.md
+++ b/agents/code-archaeologist.md
@@ -1,3 +1,7 @@
+---
+name: code-archaeologist
+description: "Expert in legacy code, refactoring, and understanding undocumented systems."
+---
 # Code Archaeologist
 
 ## Role

--- a/agents/coder.md
+++ b/agents/coder.md
@@ -1,3 +1,7 @@
+---
+name: coder
+description: "Write clean, efficient code following project conventions."
+---
 # Coder Agent
 
 ## Role

--- a/agents/copywriter.md
+++ b/agents/copywriter.md
@@ -1,3 +1,7 @@
+---
+name: copywriter
+description: "Create marketing content with CRO optimization."
+---
 # Copywriter Agent
 
 ## Role

--- a/agents/database-admin.md
+++ b/agents/database-admin.md
@@ -1,3 +1,7 @@
+---
+name: database-admin
+description: "Manage database schema, queries, and migrations."
+---
 # Database Admin Agent
 
 ## Role

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -1,3 +1,7 @@
+---
+name: debugger
+description: "Analyze errors and bugs, identify root causes, and provide systematic fix recommendations."
+---
 # Debugger - Root Cause Analysis Expert
 
 ## Role

--- a/agents/devops-engineer.md
+++ b/agents/devops-engineer.md
@@ -1,3 +1,7 @@
+---
+name: devops-engineer
+description: "Infrastructure & CI/CD expert for Docker, Kubernetes, GitHub Actions, and deployment automation."
+---
 # DevOps Engineer Agent
 
 ## Role

--- a/agents/docs-manager.md
+++ b/agents/docs-manager.md
@@ -1,3 +1,7 @@
+---
+name: docs-manager
+description: "Manage and create documentation."
+---
 # Docs Manager Agent
 
 ## Role

--- a/agents/frontend-specialist.md
+++ b/agents/frontend-specialist.md
@@ -1,3 +1,7 @@
+---
+name: frontend-specialist
+description: "Build frontend systems with focus on performance, maintainability, and user experience."
+---
 # Senior Frontend Architect
 
 ## Role

--- a/agents/fullstack-developer.md
+++ b/agents/fullstack-developer.md
@@ -1,3 +1,7 @@
+---
+name: fullstack-developer
+description: "Develop full-stack applications from frontend to backend."
+---
 # Fullstack Developer Agent
 
 ## Role

--- a/agents/game-developer.md
+++ b/agents/game-developer.md
@@ -1,3 +1,7 @@
+---
+name: game-developer
+description: "Expert in game development with Unity, Godot, Unreal, and web-based game engines."
+---
 # Game Developer
 
 ## Role

--- a/agents/git-manager.md
+++ b/agents/git-manager.md
@@ -1,3 +1,7 @@
+---
+name: git-manager
+description: "Manage version control and Git operations."
+---
 # Git Manager Agent
 
 ## Role

--- a/agents/mobile-developer.md
+++ b/agents/mobile-developer.md
@@ -1,3 +1,7 @@
+---
+name: mobile-developer
+description: "Expert in mobile app development with React Native, Flutter, and native platforms."
+---
 # Mobile Developer
 
 ## Role

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -1,3 +1,7 @@
+---
+name: orchestrator
+description: "Coordinate multiple agents to complete complex tasks that span multiple domains."
+---
 # Orchestrator - Multi-Agent Coordination
 
 ## Role

--- a/agents/penetration-tester.md
+++ b/agents/penetration-tester.md
@@ -1,3 +1,7 @@
+---
+name: penetration-tester
+description: "Expert in penetration testing, vulnerability assessment, and security testing."
+---
 # Penetration Tester
 
 ## Role

--- a/agents/performance-optimizer.md
+++ b/agents/performance-optimizer.md
@@ -1,3 +1,7 @@
+---
+name: performance-optimizer
+description: "Expert in performance optimization, profiling, Core Web Vitals, and bundle optimization."
+---
 # Performance Optimizer
 
 ## Role

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -1,3 +1,7 @@
+---
+name: planner
+description: "Create detailed implementation plans for complex tasks."
+---
 # Planner Agent
 
 ## Role

--- a/agents/product-owner.md
+++ b/agents/product-owner.md
@@ -1,3 +1,7 @@
+---
+name: product-owner
+description: "Strategic facilitator bridging business needs and technical execution."
+---
 # Product Owner
 
 ## Role

--- a/agents/project-manager.md
+++ b/agents/project-manager.md
@@ -1,3 +1,7 @@
+---
+name: project-manager
+description: "Manage project and track progress."
+---
 # Project Manager Agent
 
 ## Role

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -1,3 +1,7 @@
+---
+name: researcher
+description: "Research external resources, APIs, and documentation."
+---
 # Researcher Agent
 
 ## Role

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -1,3 +1,7 @@
+---
+name: reviewer
+description: "Review code for quality and suggest improvements."
+---
 # Reviewer Agent
 
 ## Role

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -1,3 +1,7 @@
+---
+name: scout
+description: "Explore and search code in the current codebase."
+---
 # Scout Agent
 
 ## Role

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -1,3 +1,7 @@
+---
+name: security-auditor
+description: "Audit code for security vulnerabilities. Identify risks and provide remediation guidance."
+---
 # Security Auditor
 
 ## Role

--- a/agents/seo-specialist.md
+++ b/agents/seo-specialist.md
@@ -1,3 +1,7 @@
+---
+name: seo-specialist
+description: "SEO and GEO (Generative Engine Optimization) expert for traditional and AI-powered search engines."
+---
 # SEO Specialist
 
 ## Role

--- a/agents/tester.md
+++ b/agents/tester.md
@@ -1,3 +1,7 @@
+---
+name: tester
+description: "Write tests and ensure code quality."
+---
 # Tester Agent
 
 ## Role

--- a/agents/ui-designer.md
+++ b/agents/ui-designer.md
@@ -1,3 +1,7 @@
+---
+name: ui-designer
+description: "Design user interface and experience."
+---
 # UI/UX Designer Agent
 
 ## Role


### PR DESCRIPTION
This PR adds the mandatory YAML frontmatter (name and description) to the agent Markdown files. This metadata is required for the Gemini CLI to correctly validate and load these sub-agents.